### PR TITLE
chore: Adds a __version__ variable to help with bug reports.

### DIFF
--- a/py_maplib/maplib/__init__.py
+++ b/py_maplib/maplib/__init__.py
@@ -27,6 +27,7 @@ __all__ = [
 ]
 
 import pathlib
+from importlib.metadata import version
 from .maplib import *
 from .adding_triples import add_triples
 
@@ -60,3 +61,5 @@ else:
         :param fts_path: Path to the fts index
         """
         print("Contact Data Treehouse to try!")
+
+__version__ = version("maplib") 


### PR DESCRIPTION
I wanted to debug an issue and my normal `python -c "import maplib; print(maplib.__version__)"` to get the installed version didn't work. Seemed like an uncontroversial PR -- hope this is okay!